### PR TITLE
PMM-5184 Added --skip-server for summary cmd

### DIFF
--- a/commands/summary.go
+++ b/commands/summary.go
@@ -56,7 +56,8 @@ func (res *summaryResult) String() string {
 }
 
 type summaryCommand struct {
-	Filename string
+	Filename   string
+	SkipServer bool
 }
 
 func getServerLogs(serverURL *url.URL, serverInsecureTLS bool) (*bytes.Reader, error) {
@@ -263,6 +264,10 @@ func (cmd *summaryCommand) makeArchive() (err error) {
 		logrus.Debugf("%+v", e)
 	}
 
+	if cmd.SkipServer {
+		return //nolint:nakedret
+	}
+
 	if e := addServerData(zipW, GlobalFlags.ServerURL, GlobalFlags.ServerInsecureTLS); e != nil {
 		logrus.Warnf("Failed to add server data: %s", e)
 		logrus.Debugf("%+v", e)
@@ -292,4 +297,5 @@ func init() {
 	filename := fmt.Sprintf("summary_%s_%s.zip",
 		strings.Replace(hostname, ".", "_", -1), time.Now().Format("2006_01_02_15_04_05"))
 	SummaryC.Flag("filename", "Summary archive filename").Default(filename).StringVar(&Summary.Filename)
+	SummaryC.Flag("skip-server", "Skip server information (only local client info)").BoolVar(&Summary.SkipServer)
 }

--- a/commands/summary.go
+++ b/commands/summary.go
@@ -264,13 +264,11 @@ func (cmd *summaryCommand) makeArchive() (err error) {
 		logrus.Debugf("%+v", e)
 	}
 
-	if cmd.SkipServer {
-		return //nolint:nakedret
-	}
-
-	if e := addServerData(zipW, GlobalFlags.ServerURL, GlobalFlags.ServerInsecureTLS); e != nil {
-		logrus.Warnf("Failed to add server data: %s", e)
-		logrus.Debugf("%+v", e)
+	if !cmd.SkipServer {
+		if e := addServerData(zipW, GlobalFlags.ServerURL, GlobalFlags.ServerInsecureTLS); e != nil {
+			logrus.Warnf("Failed to add server data: %s", e)
+			logrus.Debugf("%+v", e)
+		}
 	}
 
 	return //nolint:nakedret
@@ -297,5 +295,5 @@ func init() {
 	filename := fmt.Sprintf("summary_%s_%s.zip",
 		strings.Replace(hostname, ".", "_", -1), time.Now().Format("2006_01_02_15_04_05"))
 	SummaryC.Flag("filename", "Summary archive filename").Default(filename).StringVar(&Summary.Filename)
-	SummaryC.Flag("skip-server", "Skip server information (only local client info)").BoolVar(&Summary.SkipServer)
+	SummaryC.Flag("skip-server", "Skip fetching logs.zip from PMM Server").BoolVar(&Summary.SkipServer)
 }

--- a/commands/summary_test.go
+++ b/commands/summary_test.go
@@ -31,16 +31,30 @@ func TestSummary(t *testing.T) {
 	agentlocal.SetTransport(context.TODO(), true)
 
 	f, err := ioutil.TempFile("", "pmm-admin-test-summary")
+	defer os.Remove(f.Name())
 	require.NoError(t, err)
 	assert.NoError(t, f.Close())
 
 	filename := f.Name()
 	t.Log(filename)
-	cmd := &summaryCommand{
-		Filename: filename,
-	}
-	res, err := cmd.Run()
-	require.NoError(t, err)
-	assert.NotNil(t, res)
-	assert.NoError(t, os.Remove(filename))
+	t.Run("Summary default", func(t *testing.T) {
+		cmd := &summaryCommand{
+			Filename: filename,
+		}
+		res, err := cmd.Run()
+		require.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.NoError(t, os.Remove(filename))
+	})
+
+	t.Run("Summary skip server", func(t *testing.T) {
+		cmd := &summaryCommand{
+			Filename:   filename,
+			SkipServer: true,
+		}
+		res, err := cmd.Run()
+		require.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.NoError(t, os.Remove(filename))
+	})
 }

--- a/commands/summary_test.go
+++ b/commands/summary_test.go
@@ -31,20 +31,22 @@ func TestSummary(t *testing.T) {
 	agentlocal.SetTransport(context.TODO(), true)
 
 	f, err := ioutil.TempFile("", "pmm-admin-test-summary")
-	defer os.Remove(f.Name())
 	require.NoError(t, err)
-	assert.NoError(t, f.Close())
-
 	filename := f.Name()
 	t.Log(filename)
+	defer os.Remove(filename)
+	assert.NoError(t, f.Close())
+
 	t.Run("Summary default", func(t *testing.T) {
 		cmd := &summaryCommand{
 			Filename: filename,
 		}
 		res, err := cmd.Run()
 		require.NoError(t, err)
-		assert.NotNil(t, res)
-		assert.NoError(t, os.Remove(filename))
+		expected := &summaryResult{
+			Filename: filename,
+		}
+		assert.Equal(t, expected, res)
 	})
 
 	t.Run("Summary skip server", func(t *testing.T) {
@@ -54,7 +56,9 @@ func TestSummary(t *testing.T) {
 		}
 		res, err := cmd.Run()
 		require.NoError(t, err)
-		assert.NotNil(t, res)
-		assert.NoError(t, os.Remove(filename))
+		expected := &summaryResult{
+			Filename: filename,
+		}
+		assert.Equal(t, expected, res)
 	})
 }


### PR DESCRIPTION
The --skip-server flag makes the summary cmd to add only local client
information without contacting the server.