### PR TITLE
PMM-7010 pmm-admin unregister command for the local agent

### DIFF
--- a/commands/annotation.go
+++ b/commands/annotation.go
@@ -27,13 +27,12 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/percona/pmm-admin/agentlocal"
+	"github.com/percona/pmm-admin/helpers"
 )
 
 var annotationResultT = ParseTemplate(`
 Annotation added.
 `)
-
-var errNoNode = errors.New("no node available")
 
 // annotationResult is a result of annotation command.
 type annotationResult struct{}
@@ -69,18 +68,7 @@ func (cmd *annotationCommand) nodeName() (string, error) {
 		return "", err
 	}
 
-	switch {
-	case node.Generic != nil:
-		return node.Generic.NodeName, nil
-	case node.Container != nil:
-		return node.Container.NodeName, nil
-	case node.Remote != nil:
-		return node.Remote.NodeName, nil
-	case node.RemoteRDS != nil:
-		return node.RemoteRDS.NodeName, nil
-	default:
-		return "", errors.Wrap(errNoNode, "unknown node type")
-	}
+	return helpers.GetNodeName(node)
 }
 
 func (cmd *annotationCommand) getCurrentNode() (*nodes.GetNodeOKBody, error) {

--- a/commands/management/unregister.go
+++ b/commands/management/unregister.go
@@ -40,11 +40,11 @@ func (res *unregisterResult) String() string {
 }
 
 func (cmd *unregisterCommand) Run() (commands.Result, error) {
-	agentlocalstatus, queryErr := agentlocal.GetStatus(agentlocal.RequestNetworkInfo)
-	if queryErr != nil {
-		return nil, queryErr
+	status, err := agentlocal.GetStatus(agentlocal.DoNotRequestNetworkInfo)
+	if err != nil {
+		return nil, err
 	}
-	nodeID := agentlocalstatus.NodeID
+	nodeID := status.NodeID
 
 	params := &nodes.RemoveNodeParams{
 		Body: nodes.RemoveNodeBody{
@@ -54,9 +54,9 @@ func (cmd *unregisterCommand) Run() (commands.Result, error) {
 		Context: commands.Ctx,
 	}
 
-	_, clientErr := client.Default.Nodes.RemoveNode(params)
-	if clientErr != nil {
-		return nil, clientErr
+	_, err = client.Default.Nodes.RemoveNode(params)
+	if err != nil {
+		return nil, err
 	}
 
 	return new(unregisterResult), nil

--- a/commands/management/unregister.go
+++ b/commands/management/unregister.go
@@ -64,7 +64,7 @@ func (cmd *unregisterCommand) Run() (commands.Result, error) {
 // unregister command
 var (
 	Unregister  = new(unregisterCommand)
-	UnregisterC = kingpin.Command("unregister", "Register current Node at PMM Server")
+	UnregisterC = kingpin.Command("unregister", "Unregister current Node from PMM Server")
 )
 
 func init() {

--- a/commands/management/unregister.go
+++ b/commands/management/unregister.go
@@ -1,0 +1,73 @@
+// pmm-admin
+// Copyright 2019 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package management
+
+import (
+	"github.com/percona/pmm/api/inventorypb/json/client"
+	"github.com/percona/pmm/api/inventorypb/json/client/nodes"
+	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/percona/pmm-admin/agentlocal"
+	"github.com/percona/pmm-admin/commands"
+)
+
+type unregisterCommand struct {
+	Force bool
+}
+type unregisterResult struct{}
+
+var unregisterNodeResultT = commands.ParseTemplate(`
+Local node unregistered.
+`)
+
+func (res *unregisterResult) Result() {}
+
+func (res *unregisterResult) String() string {
+	return commands.RenderTemplate(unregisterNodeResultT, res)
+}
+
+func (cmd *unregisterCommand) Run() (commands.Result, error) {
+	agentlocalstatus, queryErr := agentlocal.GetStatus(agentlocal.RequestNetworkInfo)
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	nodeID := agentlocalstatus.NodeID
+
+	params := &nodes.RemoveNodeParams{
+		Body: nodes.RemoveNodeBody{
+			NodeID: nodeID,
+			Force:  cmd.Force,
+		},
+		Context: commands.Ctx,
+	}
+
+	_, clientErr := client.Default.Nodes.RemoveNode(params)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	return new(unregisterResult), nil
+}
+
+// unregister command
+var (
+	Unregister  = new(unregisterCommand)
+	UnregisterC = kingpin.Command("unregister", "Register current Node at PMM Server")
+)
+
+func init() {
+	UnregisterC.Flag("force", "Remove this node with all dependencies").BoolVar(&Unregister.Force)
+}

--- a/commands/management/unregister.go
+++ b/commands/management/unregister.go
@@ -44,11 +44,10 @@ func (cmd *unregisterCommand) Run() (commands.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	nodeID := status.NodeID
 
 	params := &nodes.RemoveNodeParams{
 		Body: nodes.RemoveNodeBody{
-			NodeID: nodeID,
+			NodeID: status.NodeID,
 			Force:  cmd.Force,
 		},
 		Context: commands.Ctx,

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -19,10 +19,14 @@ package helpers
 import (
 	"fmt"
 
+	"github.com/percona/pmm/api/inventorypb/json/client/nodes"
 	"github.com/percona/pmm/version"
+	"github.com/pkg/errors"
 
 	"github.com/percona/pmm-admin/agentlocal"
 )
+
+var errNoNode = errors.New("no node available")
 
 // HAProxyMinPMMServerVersion contains minimum version for running HAProxy.
 const haProxyMinPMMServerVersion = "2.15.0"
@@ -61,4 +65,20 @@ func IsHAProxySupported() (bool, error) {
 	}
 
 	return true, nil
+}
+
+// GetNodeName returns node name for provided Get Node response.
+func GetNodeName(node *nodes.GetNodeOKBody) (string, error) {
+	switch {
+	case node.Generic != nil:
+		return node.Generic.NodeName, nil
+	case node.Container != nil:
+		return node.Container.NodeName, nil
+	case node.Remote != nil:
+		return node.Remote.NodeName, nil
+	case node.RemoteRDS != nil:
+		return node.RemoteRDS.NodeName, nil
+	default:
+		return "", errors.Wrap(errNoNode, "unknown node type")
+	}
 }

--- a/main.go
+++ b/main.go
@@ -84,7 +84,8 @@ func main() {
 	}()
 
 	allCommands := map[string]commands.Command{
-		management.RegisterC.FullCommand(): management.Register,
+		management.RegisterC.FullCommand():   management.Register,
+		management.UnregisterC.FullCommand(): management.Unregister,
 
 		management.AddMySQLC.FullCommand():              management.AddMySQL,
 		management.AddMongoDBC.FullCommand():            management.AddMongoDB,


### PR DESCRIPTION
Unregister command for the local agent.

```
[root@1417c4b8dc28 /]# pmm-admin unregister
Node with ID "/node_id/2378e6e6-11aa-4e7d-bbf4-91fdf4f349bf" has agents.
[root@1417c4b8dc28 /]# pmm-admin unregister --force
Local node unregistered.
```

By default, it unregisters the node if it doesn't have any agents. With the force flag, it unregisters even with agents.