### PR TITLE
PMM-8990: fix build on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+# Intellij Idea
 /.idea/
+.iml
+
 /.vscode/
 /bin/
 cover.out

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Intellij Idea
 /.idea/
-.iml
+*.iml
 
 /.vscode/
 /bin/

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,5 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1
-	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/go.sum
+++ b/go.sum
@@ -222,10 +222,6 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
-github.com/percona/pmm v0.0.0-20210729102440-72f70c96c89b h1:YlfHOmTLCgd/db8jNEb7qcHX5mSS4Ju/e0VyfdH0cYc=
-github.com/percona/pmm v0.0.0-20210729102440-72f70c96c89b/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
-github.com/percona/pmm v0.0.0-20210729105219-685e1d7efb1e h1:p0FiSjHr0T48mcvaTOeIhpxoecnuLmShGpdss2StgDs=
-github.com/percona/pmm v0.0.0-20210729105219-685e1d7efb1e/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
 github.com/percona/pmm v0.0.0-20210730110700-154612d18048 h1:jXsMe/Twq9SVXqw6fdR9RFRm2tV9xTY9N3+SePANSZ8=
 github.com/percona/pmm v0.0.0-20210730110700-154612d18048/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/main.go
+++ b/main.go
@@ -19,14 +19,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/percona/pmm/version"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v2"
 	"os"
 	"os/exec"
 	"os/signal"
-
-	"github.com/percona/pmm/version"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
-	"gopkg.in/alecthomas/kingpin.v2"
+	"syscall"
 
 	"github.com/percona/pmm-admin/commands"
 	"github.com/percona/pmm-admin/commands/inventory"
@@ -75,11 +74,11 @@ func main() {
 
 	// handle termination signals
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, unix.SIGTERM, unix.SIGINT)
+	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		s := <-signals
 		signal.Stop(signals)
-		logrus.Warnf("Got %s, shutting down...", unix.SignalName(s.(unix.Signal)))
+		logrus.Warnf("Got %s, shutting down...", s.String())
 		cancel()
 	}()
 


### PR DESCRIPTION
use generic syscall instead of depending on unix package