### PR TITLE
PMM-8259 Update custom message for server error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
   matrix:
     - PMM_SERVER_IMAGE=percona/pmm-server:2.0.0
     - PMM_SERVER_IMAGE=percona/pmm-server:2
-    - PMM_SERVER_IMAGE=public.ecr.aws/e7j3v3n0/pmm-server:dev-latest
+    - PMM_SERVER_IMAGE=perconalab/pmm-server:dev-latest
 
 before_install:
   - docker-compose up -d

--- a/main.go
+++ b/main.go
@@ -189,6 +189,9 @@ func main() {
 			fmt.Printf("%s\n", b)
 		} else {
 			msg := e.Error
+			if e.Code == 401 {
+				msg += ". Please check username and password."
+			}
 			fmt.Println(msg)
 		}
 

--- a/main.go
+++ b/main.go
@@ -189,9 +189,6 @@ func main() {
 			fmt.Printf("%s\n", b)
 		} else {
 			msg := e.Error
-			if e.Code == 401 || e.Code == 403 {
-				msg += ". Please check username and password."
-			}
 			fmt.Println(msg)
 		}
 


### PR DESCRIPTION
In case of 401 or 403 HTTP status response from server, pmm-admin
appends a custom message to error response from server. The message
causes mismatch between HTTP status code and updated error message.

With this change, we will provide custom message only for 401 HTTP status code. This will avoid mismatch between HTTP status code and additional error message.