### PR TITLE
PMM-6075: Add go-consistent to reviewdog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,4 @@ env-down:                       ## Stop development environment.
 ci-reviewdog:                   ## Runs reviewdog checks.
 	$(BIN_PATH)/golangci-lint run -c=.golangci-required.yml --out-format=line-number | $(BIN_PATH)/reviewdog -f=golangci-lint -level=error -reporter=github-pr-check
 	$(BIN_PATH)/golangci-lint run -c=.golangci.yml --out-format=line-number | $(BIN_PATH)/reviewdog -f=golangci-lint -level=error -reporter=github-pr-review
+	$(BIN_PATH)/go-consistent -pedantic -exclude "tests" ./... | $(BIN_PATH)/reviewdog -f=go-consistent -name='Required go-consistent checks' -reporter=github-pr-check


### PR DESCRIPTION
This includes go-consistent in CI to be reported by reviewdog as part of [PMM-6075](https://jira.percona.com/browse/PMM-6075?filter=-1). Already, we can run `go-consistent` locally with `make check-style`.

Not yet sure about the practical differences between using `-pedantic` flag and not, so it still stays.